### PR TITLE
Fix shading of NBTAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <relocations>
                                 <relocation>
-                                    <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                                    <pattern>de.tr7zw.nbtapi</pattern>
                                     <shadedPattern>me.orineko.thirstbar.nbtapi</shadedPattern>
                                 </relocation>
                                 <relocation>


### PR DESCRIPTION
Not shading properly caused this warning upon startup;

#########################################- NBTAPI -#########################################
The NBT-API inside ThirstBar is located at 'de.tr7zw.nbtapi.utils'!
This package name is reserved for the official NBTAPI plugin, and not intended to be used for shading!
Please change the relocate to something else. For example: com.example.util.nbtapi
#########################################- NBTAPI -#########################################